### PR TITLE
headjack cli command to start the server

### DIFF
--- a/headjack/api/app.py
+++ b/headjack/api/app.py
@@ -1,6 +1,7 @@
 """
 Headjack web server
 """
+import argparse
 import logging
 
 import uvicorn
@@ -24,6 +25,13 @@ app.include_router(chat.router)
 app.include_router(summary.router)
 app.include_router(metric_search.router)
 app.include_router(metric_calculate.router)
+
+def cli():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", help="Host")
+    parser.add_argument("--port", help="Port", type=int)
+    args = parser.parse_args()
+    uvicorn.run(app, host=args.host, port=args.port)
 
 if __name__ == "__main__":
     settings = get_settings()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ requires-python = ">=3.10,<4.0"
 readme = "README.md"
 license = {text = "Aache 2.0"}
 
+[project.scripts]
+headjack = "headjack.api.app:cli"
+
 [tool.pdm.dev-dependencies]
 dev = [
     "pytest==7.2.2",


### PR DESCRIPTION
This lets you start headjack with a `headjack` command after pip installing.

```sh
pip install headjack
```
```
headjack --host 0.0.0.0 --port 8679
```

(If you just run `headjack` it defaults to `--host 0.0.0.0 --port 8679`)