### PR TITLE
update submodules to https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "docker/chroma"]
   path = docker/chroma
-  url = git@github.com:chroma-core/chroma.git
+  url = https://github.com/chroma-core/chroma.git
 [submodule "docs/themes/DoIt"]
 	path = docs/themes/DoIt
-	url = git@github.com:HEIGE-PCloud/DoIt.git
+	url = https://github.com/HEIGE-PCloud/DoIt.git

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 # Helpful gist to see all available values
 # https://gist.github.com/DavidWells/43884f15aed7e4dcb3a6dad06430b756
 [build]
-  base = "docs/"
+  base = "docs"
   command = "./build-docs.sh 0.1.0 true $DEPLOY_URL"
   publish = "docs/public"
 


### PR DESCRIPTION
Netlify can't clone the submodules without ssh keys so I updated them to https.